### PR TITLE
Use the same track colors as defined in HTML schedule.

### DIFF
--- a/app/src/ccc33c3/res/values/colors_congress.xml
+++ b/app/src/ccc33c3/res/values/colors_congress.xml
@@ -22,47 +22,63 @@
 
     <!-- Default state -->
     <color name="event_border_default">#333333</color>
-    <color name="event_border_default_art_culture">#66241c</color>
-    <color name="event_border_default_ccc">#663414</color>
-    <color name="event_border_default_entertainment">#664000</color>
-    <color name="event_border_default_ethics_society_politics">#2c2048</color>
-    <color name="event_border_default_hardware_making">#281035</color>
-    <color name="event_border_default_other">#385049</color>
-    <color name="event_border_default_science">#622562</color>
-    <color name="event_border_default_security_hacking">#26492c</color>
+    <color name="event_border_default_art_culture">#ba4c73</color>
+    <color name="event_border_default_ccc">#b3aa50</color>
+    <color name="event_border_default_entertainment">#7a9412</color>
+    <color name="event_border_default_ethics_society_politics">#006661</color>
+    <color name="event_border_default_hardware_making">#4f3669</color>
+    <color name="event_border_default_other">#388f75</color>
+    <color name="event_border_default_podcastingtisch">#51529C</color>
+    <color name="event_border_default_science">#005c91</color>
+    <color name="event_border_default_security_hacking">#9c2434</color>
+    <color name="event_border_default_self_organized_sessions">#E83589</color>
+    <color name="event_border_default_sendezentrumsbuehne">#b5742a</color>
+    <color name="event_border_default_space">#242424</color>
 
     <!-- Highlight state -->
     <color name="event_border_highlight">@color/event_border_default</color>
-    <color name="event_border_highlight_art_culture">#ff5a46</color>
-    <color name="event_border_highlight_ccc">#ff8232</color>
-    <color name="event_border_highlight_entertainment">#ffa000</color>
-    <color name="event_border_highlight_ethics_society_politics">#6e50b4</color>
-    <color name="event_border_highlight_hardware_making">#ff561876</color>
-    <color name="event_border_highlight_other">#489d84</color>
-    <color name="event_border_highlight_science">#b846b8</color>
-    <color name="event_border_highlight_security_hacking">#2d9d42</color>
+    <color name="event_border_highlight_art_culture">#EC6090</color>
+    <color name="event_border_highlight_ccc">#e1d33e</color>
+    <color name="event_border_highlight_entertainment">#A2C617</color>
+    <color name="event_border_highlight_ethics_society_politics">#009A93</color>
+    <color name="event_border_highlight_hardware_making">#75519C</color>
+    <color name="event_border_highlight_other">#4bc29f</color>
+    <color name="event_border_highlight_podcastingtisch">#51529C</color>
+    <color name="event_border_highlight_science">#007BC4</color>
+    <color name="event_border_highlight_security_hacking">#E7344C</color>
+    <color name="event_border_highlight_self_organized_sessions">#E83589</color>
+    <color name="event_border_highlight_sendezentrumsbuehne">#E89535</color>
+    <color name="event_border_highlight_space">#575757</color>
 
     <!--Accent color-->
     <color name="event_border_accent">#888</color>
-    <color name="event_border_accent_art_culture">#ff5a46</color>
-    <color name="event_border_accent_ccc">#ff8232</color>
-    <color name="event_border_accent_entertainment">#ffa000</color>
-    <color name="event_border_accent_ethics_society_politics">#6e50b4</color>
-    <color name="event_border_accent_hardware_making">#ff6b3491</color>
-    <color name="event_border_accent_other">#4bc29f</color>
-    <color name="event_border_accent_science">#b846b8</color>
-    <color name="event_border_accent_security_hacking">#36b94e</color>
+    <color name="event_border_accent_art_culture">@color/event_border_highlight_art_culture</color>
+    <color name="event_border_accent_ccc">@color/event_border_highlight_ccc</color>
+    <color name="event_border_accent_entertainment">@color/event_border_highlight_entertainment</color>
+    <color name="event_border_accent_ethics_society_politics">@color/event_border_highlight_ethics_society_politics</color>
+    <color name="event_border_accent_hardware_making">@color/event_border_highlight_hardware_making</color>
+    <color name="event_border_accent_other">@color/event_border_highlight_other</color>
+    <color name="event_border_accent_podcastingtisch">@color/event_border_highlight_podcastingtisch</color>
+    <color name="event_border_accent_science">@color/event_border_highlight_science</color>
+    <color name="event_border_accent_security_hacking">@color/event_border_highlight_security_hacking</color>
+    <color name="event_border_accent_self_organized_sessions">@color/event_border_highlight_self_organized_sessions</color>
+    <color name="event_border_accent_sendezentrumsbuehne">@color/event_border_highlight_sendezentrumsbuehne</color>
+    <color name="event_border_accent_space">@color/event_border_highlight_space</color>
 
     <!--Accent color highlight-->
     <color name="event_border_accent_highlight">#888</color>
-    <color name="event_border_accent_highlight_art_culture">#9d1100</color>
-    <color name="event_border_accent_highlight_ccc">#b14500</color>
-    <color name="event_border_accent_highlight_entertainment">#ae6600</color>
-    <color name="event_border_accent_highlight_ethics_society_politics">#462c82</color>
-    <color name="event_border_accent_highlight_hardware_making">#ffb745e8</color>
-    <color name="event_border_accent_highlight_other">#385049</color>
-    <color name="event_border_accent_highlight_science">#ffff77fc</color>
-    <color name="event_border_accent_highlight_security_hacking">#1c6028</color>
+    <color name="event_border_accent_highlight_art_culture">@color/event_border_default_art_culture</color>
+    <color name="event_border_accent_highlight_ccc">@color/event_border_default_ccc</color>
+    <color name="event_border_accent_highlight_entertainment">@color/event_border_default_entertainment</color>
+    <color name="event_border_accent_highlight_ethics_society_politics">@color/event_border_default_ethics_society_politics</color>
+    <color name="event_border_accent_highlight_hardware_making">@color/event_border_default_hardware_making</color>
+    <color name="event_border_accent_highlight_other">@color/event_border_default_other</color>
+    <color name="event_border_accent_highlight_podcastingtisch">@color/event_border_default_podcastingtisch</color>
+    <color name="event_border_accent_highlight_science">@color/event_border_default_science</color>
+    <color name="event_border_accent_highlight_security_hacking">@color/event_border_default_security_hacking</color>
+    <color name="event_border_accent_highlight_self_organized_sessions">@color/event_border_default_self_organized_sessions</color>
+    <color name="event_border_accent_highlight_sendezentrumsbuehne">@color/event_border_default_sendezentrumsbuehne</color>
+    <color name="event_border_accent_highlight_space">@color/event_border_default_space</color>
 
     <!--Title color-->
     <color name="event_title">#a0ffffff</color>

--- a/app/src/ccc33c3/res/xml/track_resource_names.xml
+++ b/app/src/ccc33c3/res/xml/track_resource_names.xml
@@ -5,7 +5,11 @@
     <entry key="Entertainment">entertainment</entry>
     <entry key="Ethics, Society &amp; Politics">ethics_society_politics</entry>
     <entry key="Hardware &amp; Making">hardware_making</entry>
+    <entry key="Podcastingtisch">podcastingtisch</entry>
     <entry key="Science">science</entry>
     <entry key="Security">security_hacking</entry>
+    <entry key="self organized sessions">self_organized_sessions</entry>
+    <entry key="Sendezentrumsbühne">sendezentrumsbuehne</entry>
+    <entry key="Space">space</entry>
     <entry key="Other">other</entry>
 </map>


### PR DESCRIPTION
+ Define missing track category "Space".
+ Add tracks and custom colors for "Podcastingtisch",
  "self organized sessions" and "Sendezentrumsbühne".

### Before

![before](https://cloud.githubusercontent.com/assets/144518/21471950/54a17cf6-cac5-11e6-85c6-f5e3b162e2fe.png)

### After

![after](https://cloud.githubusercontent.com/assets/144518/21471953/5a993b9e-cac5-11e6-8a49-3759234f8587.png)
