### PR TITLE
Add 20 minutes as a possible alarm time

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -6,6 +6,7 @@
         <item>5 minutes</item>
         <item>10 minutes</item>
         <item>15 minutes</item>
+        <item>20 minutes</item>
         <item>30 minutes</item>
         <item>45 minutes</item>
         <item>60 minutes</item>
@@ -17,6 +18,7 @@
         <item>5</item>
         <item>10</item>
         <item>15</item>
+        <item>20</item>
         <item>30</item>
         <item>45</item>
         <item>60</item>


### PR DESCRIPTION
VOC angels (and possibly others that manage talks) need to be in their hall 15 minutes before the talk begins. A 20 minutes "you have to go now" notification would be very helpful for this.